### PR TITLE
Parallelize customer run extraction with env toggle

### DIFF
--- a/main.py
+++ b/main.py
@@ -588,7 +588,7 @@ def _exception_message(exc: Exception) -> str:
 
 
 def _is_parallel_extract_enabled() -> bool:
-    raw = str(os.getenv("ME_CHECK_PARALLEL_EXTRACT", "1") or "").strip().lower()
+    raw = os.getenv("ME_CHECK_PARALLEL_EXTRACT", "1").strip().lower()
     return raw not in {"0", "false"}
 
 
@@ -915,8 +915,13 @@ async def handle_customer_run(
             ),
             return_exceptions=True,
         )
-        raster_exc = raster_result if isinstance(raster_result, Exception) else None
-        vector_exc = vector_result if isinstance(vector_result, Exception) else None
+        raster_exc = raster_result if isinstance(raster_result, BaseException) else None
+        vector_exc = vector_result if isinstance(vector_result, BaseException) else None
+
+        if isinstance(raster_exc, asyncio.CancelledError):
+            raise raster_exc
+        if isinstance(vector_exc, asyncio.CancelledError):
+            raise vector_exc
 
         if raster_exc and vector_exc:
             print(f"Customer flow failed at panel->raster: {raster_exc}")


### PR DESCRIPTION
## 概要
`POST /customer/run` に限定して、`raster` 抽出と `vector` 抽出を並列実行できるようにしました。  
HF無料枠運用を意識し、環境変数で即時に直列へ戻せるフォールバックを追加しています。

## 変更内容
- `/customer/run` の実行順を再構成
  - 先に `panel_file` / `equipment_file` を `await ...read()`
  - 並列ON時: `asyncio.to_thread` + `asyncio.gather(return_exceptions=True)` で `raster` / `vector` を同時実行
  - 並列OFF時: 従来どおり `raster -> vector` の直列実行
- `unified` 実行も `asyncio.to_thread` 化（イベントループのブロッキング抑制）
- 環境変数 `ME_CHECK_PARALLEL_EXTRACT` を追加
  - デフォルト: `1`（並列有効）
  - `0` / `false` / `False` の場合は直列実行
- エラー判定ルールを明確化
  - raster失敗: `stage="panel->raster"`
  - vector失敗: `stage="equipment->vector"`
  - 両方失敗: `panel->raster` を優先して返却（ログには両方出力）
  - unified失敗: `stage="unified"`（従来どおり）

## 非変更
- 公開APIのパス・レスポンス形式
- `/me-check/develop` 系エンドポイント（`/raster/upload`, `/vector/upload`, `/unified/merge`）
- CSV列仕様、判定ロジック、HTML列表示

## テスト
既存 + 追加テストを実施し、以下すべて通過。

- `python3 -m pytest -q tests/test_integration_routes.py -k customer_run`
- `python3 -m pytest -q tests/test_integration_routes.py`

追加した主なテスト:
- 並列実行確認（`threading.Event` 使用）
- `ME_CHECK_PARALLEL_EXTRACT=0` 時の直列フォールバック確認
- 両抽出失敗時の優先ルール（`panel->raster`）とログ出力確認

## 運用メモ
負荷や安定性問題が出た場合は、`ME_CHECK_PARALLEL_EXTRACT=0` で即時に直列へ戻せます。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled concurrent processing of raster and vector extraction jobs for improved performance.
  * Added feature flag to control parallel execution with automatic sequential fallback when disabled.

* **Tests**
  * Added comprehensive test coverage for parallel execution, sequential processing fallback, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->